### PR TITLE
add validity check for UUIDs

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -103,3 +103,13 @@ test('parse/unparse', function() {
     '00112233-4455-6677-8899-aabbccddeeff', 'Dirty parse');
 });
 
+test('valid', function() {
+  var illegalChars = 'thisisnotavalidid';
+  var short = '00112233-4455-6677-8899-aabbccddeef';
+  var separators = '00112233445566778899aabbccddeef';
+  assert(uuid.valid(uuid.v1()), 'generated id v1 is valid');
+  assert(uuid.valid(uuid.v4()), 'generated id v4 is valid');
+  assert(uuid.valid(illegalChars) === false, 'illegal chars are invalid');
+  assert(uuid.valid(short) === false, 'too short is invalid');
+  assert(uuid.valid(separators) === false, 'missing separators is invalid');
+})

--- a/uuid.js
+++ b/uuid.js
@@ -16,6 +16,11 @@ for (var i = 0; i < 256; i++) {
   _hexToByte[_byteToHex[i]] = i;
 }
 
+// **`valid()` - Check if a UUID has valid format (RFC)**
+function valid(s) {
+  return /[a-f,A-F,0-9]{8}-([a-f,A-F,0-9]{4}-){3}[a-f,A-F,0-9]{12}/.test(s);
+}
+
 // **`parse()` - Parse a UUID into it's component bytes**
 function parse(s, buf, offset) {
   var i = (buf && offset) || 0, ii = 0;
@@ -179,5 +184,6 @@ uuid.v1 = v1;
 uuid.v4 = v4;
 uuid.parse = parse;
 uuid.unparse = unparse;
+uuid.valid = valid;
 
 module.exports = uuid;


### PR DESCRIPTION
New function `valid()` checks against the formal definition for UUID
string representation, as described in the ABNF from RFC 4122, section 3,
page 3.

Should solve #19.
